### PR TITLE
Fixing yaml dependency installation

### DIFF
--- a/azure_functions_devops_build/exceptions.py
+++ b/azure_functions_devops_build/exceptions.py
@@ -9,3 +9,7 @@ class GitOperationException(BaseException):
 
 class RoleAssignmentException(BaseException):
     pass
+
+
+class LanguageNotSupportException(BaseException):
+    pass

--- a/azure_functions_devops_build/yaml/templates/build.jinja
+++ b/azure_functions_devops_build/yaml/templates/build.jinja
@@ -1,3 +1,7 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
 # Starter template for Azure functions build -- {{language}} on {{platform}}
 trigger:
 - master

--- a/azure_functions_devops_build/yaml/yaml_manager.py
+++ b/azure_functions_devops_build/yaml/yaml_manager.py
@@ -79,9 +79,6 @@ class YamlManager(object):
                 return bool(json_object.get('scripts', {}).get('build'))
         return False
 
-    def _requires_mvn(self):
-        return path.exists('pom.xml')
-
     def _python_dependencies(self):
         """Helper to create the standard python dependencies"""
         dependencies = []

--- a/azure_functions_devops_build/yaml/yaml_manager.py
+++ b/azure_functions_devops_build/yaml/yaml_manager.py
@@ -41,6 +41,11 @@ class YamlManager(object):
             language_str = 'dotnet'
             package_route = '$(System.DefaultWorkingDirectory)/publish_output/s'
             dependencies = self._dotnet_dependencies()
+        elif self._language == JAVA:
+            language_str = 'java'
+            package_route = '$(System.DefaultWorkingDirectory)'
+            dependencies = self._java_dependencies()
+            # ADD NEW DEPENDENCIES FOR LANGUAGES HERE
         else:
             raise LanguageNotSupportException(self._language)
 
@@ -67,15 +72,11 @@ class YamlManager(object):
     def _requires_pip(self):
         return path.exists('requirements.txt')
 
-    def _requires_npm(self):
-        return path.exists('package.json')
-
     def _requires_npm_build(self):
         if path.exists('package.json'):
             with open('package.json', 'r') as f:
                 json_object = json.load(f)
                 return bool(json_object.get('scripts', {}).get('build'))
-            return False
         return False
 
     def _requires_mvn(self):
@@ -132,3 +133,13 @@ class YamlManager(object):
         dependencies.append("    modifyOutputPath: true")
         dependencies.append("    zipAfterPublish: false")
         return dependencies
+
+    def _java_dependencies(self):
+        """Helper to create the standard java dependencies"""
+        dependencies = ['- script: |', '    dotnet restore', '    dotnet build', '   mvn clean deploy']
+        logging.critical("java dependencies are currently not implemented")
+        return dependencies
+
+    def _powershell_dependencies(self):
+        # TODO
+        exit(1)

--- a/azure_functions_devops_build/yaml/yaml_manager.py
+++ b/azure_functions_devops_build/yaml/yaml_manager.py
@@ -72,6 +72,9 @@ class YamlManager(object):
     def _requires_pip(self):
         return path.exists('requirements.txt')
 
+    def _requires_npm(self):
+        return path.exists('package.json')
+
     def _requires_npm_build(self):
         if path.exists('package.json'):
             with open('package.json', 'r') as f:

--- a/azure_functions_devops_build/yaml/yaml_manager.py
+++ b/azure_functions_devops_build/yaml/yaml_manager.py
@@ -64,7 +64,7 @@ class YamlManager(object):
     def _requires_extensions(self):
         return path.exists('extensions.csproj')
 
-    def _requires_python_requirements(self):
+    def _requires_pip(self):
         return path.exists('requirements.txt')
 
     def _requires_npm(self):
@@ -97,7 +97,7 @@ class YamlManager(object):
         dependencies.append('    python3.6 -m venv worker_venv')
         dependencies.append('    source worker_venv/bin/activate')
         dependencies.append('    pip3.6 install setuptools')
-        if self._requires_python_requirements():
+        if self._requires_pip():
             dependencies.append('    pip3.6 install -r requirements.txt')
         return dependencies
 


### PR DESCRIPTION
### The dependency installation procedure should only work when a dependency description file is presented in the local repository.

**This pull request is intended to fix the issues in following scenarios:**
1. Failure when a python repository **does not have a requirements.txt** file. The build should not fail and the "pip install" step should be skipped.
2. Failure when a javascript repository **does not have a package.json** file. The build should not fail and the "npm install" step should be skipped.
3. Failure when a javascript repository with a package.json file, but it does not have a "build" command defined in the "scripts" block. The build should not fail and the "npm build" step should be skipped.

### Miscellaneous
1. Currently we do not support Java and Powershell in devops-build tool. We should remove them from local repository.