### PR TITLE
Include build jinja template, LICENSE and README.md in build manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include *.jinja
+include azure_functions_devops_build/yaml/templates/*.jinja
+include LICENSE README.md


### PR DESCRIPTION
Previously, we are missing build.jinja template when distributing the Python packages.
We fix the issue and make sure all necessary files are included in release.