### PR TITLE
Detect if git has credential manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ for organization in organizations.value:
 
 ## API documentation
 
-This Python library extensively uses the Azure DevOps REST APIs and Azure Devops Python API. See the [Azure DevOps REST API reference](https://docs.microsoft.com/en-us/rest/api/vsts/?view=vsts-rest-5.0) for details on calling different APIs and [Azure DevOps Python SDK] (https://github.com/Microsoft/azure-devops-python-api) for details on the azure-devops-python-api.
+This Python library extensively uses the Azure DevOps REST APIs and Azure Devops Python API. See the [Azure DevOps REST API reference](https://docs.microsoft.com/en-us/rest/api/vsts/?view=vsts-rest-5.0) for details on calling different APIs and [Azure DevOps Python SDK](https://github.com/Microsoft/azure-devops-python-api) for details on the azure-devops-python-api.
 
 ## Samples
 

--- a/azure_functions_devops_build/repository/local_git_utils.py
+++ b/azure_functions_devops_build/repository/local_git_utils.py
@@ -34,6 +34,15 @@ def does_git_remote_exist(remote_name):
 
     return remote_name in output
 
+def does_git_has_credential_manager():
+    command = ["git", "config", "--list"]
+    try:
+        output = check_output(command).decode("utf-8").split("\n")
+    except CalledProcessError:
+        raise GitOperationException(message=" ".join(command))
+
+    return "credential.helper=manager" in output
+
 def git_init():
     command = ["git", "init"]
     try:

--- a/azure_functions_devops_build/repository/repository_manager.py
+++ b/azure_functions_devops_build/repository/repository_manager.py
@@ -18,6 +18,7 @@ from .local_git_utils import (
         git_push,
         does_git_exist,
         does_local_git_repository_exist,
+        does_git_has_credential_manager,
         does_git_remote_exist,
         construct_git_remote_name,
         construct_git_remote_url
@@ -45,6 +46,10 @@ class RepositoryManager(BaseManager):
     @staticmethod
     def check_git_local_repository():
         return does_local_git_repository_exist()
+
+    @staticmethod
+    def check_git_credential_manager():
+        return does_git_has_credential_manager()
 
     # Check if the git repository exists first. If it does, check if the git remote exists.
     def check_git_remote(self, repository_name, remote_prefix):


### PR DESCRIPTION
If git does not have a credential manager, we should lead the user to Azure Devops https://dev.azure.com/{org}/_usersSettings/altcreds and ask them to setup a temporary credential.