### PR TITLE
Release 17

### DIFF
--- a/azure_functions_devops_build/yaml/github_yaml_manager.py
+++ b/azure_functions_devops_build/yaml/github_yaml_manager.py
@@ -3,8 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from os import path
 from datetime import datetime
-from jinja2 import Environment, PackageLoader, select_autoescape
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from ..repository.github_repository_manager import GithubRepositoryManager
 from ..base.base_github_manager import BaseGithubManager
 from ..constants import (WINDOWS, PYTHON, NODE, DOTNET)
@@ -20,8 +21,8 @@ class GithubYamlManager(BaseGithubManager):
         self._language = language
         self._app_type = app_type
         self.jinja_env = Environment(
-            loader=PackageLoader('azure_functions_devops_build.yaml', 'templates'),
-            autoescape=select_autoescape(['html', 'xml', 'jinja'])
+            loader=FileSystemLoader(path.join(path.abspath(path.dirname(__file__)), 'templates')),
+            autoescape=select_autoescape(['jinja'])
         )
 
     def create_yaml(self, overwrite=False):

--- a/azure_functions_devops_build/yaml/yaml_manager.py
+++ b/azure_functions_devops_build/yaml/yaml_manager.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import os.path as path
-from jinja2 import Environment, PackageLoader, select_autoescape
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from ..constants import (WINDOWS, PYTHON, NODE, DOTNET)
 from ..exceptions import LanguageNotSupportException
 
@@ -21,8 +21,8 @@ class YamlManager(object):
         self._language = language
         self._app_type = app_type
         self.jinja_env = Environment(
-            loader=PackageLoader('azure_functions_devops_build.yaml', 'templates'),
-            autoescape=select_autoescape(['html', 'xml', 'jinja'])
+            loader=FileSystemLoader(path.join(path.abspath(path.dirname(__file__)), 'templates')),
+            autoescape=select_autoescape(['jinja'])
         )
 
     def create_yaml(self):

--- a/setup.py
+++ b/setup.py
@@ -4,25 +4,25 @@
 # license information.
 #--------------------------------------------------------------------------
 
+from os import path
 from setuptools import setup, find_packages
 
 NAME = "azure-functions-devops-build"
-VERSION = "0.0.16"
+VERSION = "0.0.17"
 
-# To install the library, run the following
-#
-# python setup.py install
-#
-# prerequisite: setuptools
-# http://pypi.python.org/pypi/setuptools
+REQUIRES = ["msrest>=0.6.4",
+            "vsts>=0.1.25",
+            "Jinja2>=2.10"]
 
-REQUIRES = ["msrest",
-            "vsts",
-            "jinja2"]
+file_directory = path.abspath(path.dirname(__file__))
+
+with open(path.join(file_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
 
 setup(
     name=NAME,
     version=VERSION,
+    license="MIT",
     description="Python package for integrating Azure Functions with Azure DevOps. Specifically made for the Azure CLI",
     author="Oliver Dolk, Hanzhang Zeng",
     author_email="t-oldolk@microsoft.com, hazeng@microsoft.com",
@@ -31,5 +31,6 @@ setup(
     install_requires=REQUIRES,
     packages=find_packages(exclude=["tests", "sample_yaml_builds"]),
     include_package_data=True,
-    long_description=""
+    long_description=long_description,
+    long_description_content_type='text/markdown'
 )


### PR DESCRIPTION
### Fix Windows Azure-CLI version issue
Previously, when packaging .msi installer for Windows user
1. the Azure-CLI source files are set in C:\Users\VSSADM~1\AppData\Local\Temp\pip-install-xxxxxxxx
2. the site-packages for Azure-CLI is set in D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages
3. However, the site-package's site-packages is located back in C:\Users\VSSADM~1\AppData\Local\Temp

That's the cause why resolving .jinja template file with PackageLoader is not reliable.